### PR TITLE
setup-yq-action is fixed in CI

### DIFF
--- a/.github/workflows/my_workflow.yaml
+++ b/.github/workflows/my_workflow.yaml
@@ -19,5 +19,7 @@ jobs:
         run: npm install -g bats
       - name: run bats version
         run: bats -v
-
-
+      - name: Setup yq environment #Configurar entorno yq
+        uses: shiipou/setup-yq-action@v2.2.0
+      - name: print yq version
+        run: yq --version


### PR DESCRIPTION
I see you tried to use my YQ action, but i didn't see Github changes permissions to they runners.
Now it's fixed and you can use it in this way.
I also add some inputs to allow you to use it if the case appear again without the need to wait for me to do it. (check the [action.yml](https://github.com/shiipou/setup-yq-action/blob/beta/action.yaml) file of the action)